### PR TITLE
Fix containsPlaceholder

### DIFF
--- a/fzz.go
+++ b/fzz.go
@@ -47,7 +47,7 @@ func isPipe(f *os.File) bool {
 
 func containsPlaceholder(s []string, ph string) bool {
 	for _, v := range s {
-		if v == ph {
+		if strings.Contains(v, ph) {
 			return true
 		}
 	}


### PR DESCRIPTION
The check was too strict and broke things like:

```
$ fzz find ./Documents -iname "*{{}}*"
No placeholder in arguments
```
