### PR TITLE
Fix Runner.streamOutput

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -78,10 +78,12 @@ func (r *Runner) streamOutput(stdout io.ReadCloser) <-chan string {
 	go func() {
 		for {
 			line, err := cmdreader.ReadBytes('\n')
+			if line != nil {
+				ch <- string(line)
+			}
 			if err != nil || err == io.EOF {
 				break
 			}
-			ch <- string(line)
 		}
 		close(ch)
 	}()


### PR DESCRIPTION
streamOutput dropped the last line if it doesn't end with a '\n'. 

```
$ echo -ne "line1\nline2" > noendnl
$ fzz cat {{}}
>> noendnl
line1
```
