### PR TITLE
Improve utf8 handling

### DIFF
--- a/fzz.go
+++ b/fzz.go
@@ -152,7 +152,12 @@ func main() {
 		switch b[0] {
 		case keyBackspace, keyDelete:
 			if len(input) > 1 {
-				input = input[:len(input)-1]
+				r, rsize := utf8.DecodeLastRune(input)
+				if r == utf8.RuneError {
+					input = input[:len(input)-1]
+				} else {
+					input = input[:len(input)-rsize]
+				}
 			} else if len(input) == 1 {
 				input = nil
 			}


### PR DESCRIPTION
Cursor position was off for non ascii input e.g.:

```
$ fzz grep {{}} /usr/share/dict/german
>> ä.*ö  _
Aufklärungsmöglichkeit
Aufklärungsmöglichkeiten
....
```

Similar, when backspacing only a single byte got removed from the utf8 sequence.
